### PR TITLE
Fix stringify of objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,39 +1,37 @@
 'use strict'
 
-var yaml = require('js-yaml'),
-  fs = require('fs');
+const {readFileSync} = require('fs');
 
-function parse(src) {
-  var result = yaml.load(src);
-  return result ? result : { };
+const {load} = require('js-yaml');
+
+
+function loadIntoEnv(parsed)
+{
+  const {env} = process
+  for(const key in parsed)
+    if(!env.hasOwnProperty(key))
+    {
+      const value = parsed[key]
+
+      env[key] = typeof value === 'string' ? value : JSON.stringify(value)
+    }
 }
 
-function config(options) {
-  var path = '.env.yml',
-    encoding = 'utf8';
 
-  if (options) {
-    if (options.path) {
-      path = options.path;
-    }
-    if (options.encoding) {
-      encoding = options.encoding;
-    }
-  }
+function config({encoding = 'utf8', intoEnv = true, path} = {}) {
+  if(!path) path = resolve(process.cwd(), '.env.yml');
 
   try {
-    var parsedDoc = parse(fs.readFileSync(path, { encoding: encoding }));
+    const parsed = load(readFileSync(path, { encoding }));
     
-    Object.keys(parsedDoc).forEach(function(key) {
-      process.env[key] = process.env[key] || parsedDoc[key];
-    });
+    intoEnv !== false && loadIntoEnv(parsed);
 
-    return { parsed: parsedDoc };
-  } catch (e) {
-    return { error: e };
+    return { parsed };
+  } catch (error) {
+    return { error };
   }
 }
 
-module.exports.config = config;
-module.exports.load = config;
-module.exports.parse = parse;
+
+exports.config = config;
+exports.load = config;


### PR DESCRIPTION
When parsing an object from a yaml file, it was set in `process.env` as `[Object object]`. This changes fix that, and also use some new EcmaScript features and an option to disable loading into `process.env`.