### PR TITLE
Added optional namespace parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ using this option.
 ```javascript
 require('env-yaml').config({ encoding: 'base64' });
 ```
+
+### Namespace
+
+Default: null
+
+You may specify a namespace in which to fetch your environment variables. Useful when you want to store environment specific values within the same files.
+
+```javascript
+require('env-yaml').config({ namespace: 'development' });
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,8 @@ function parse(src) {
 
 function config(options) {
   var path = '.env.yml',
-    encoding = 'utf8';
+    encoding = 'utf8',
+    namespace = null;
 
   if (options) {
     if (options.path) {
@@ -19,16 +20,19 @@ function config(options) {
     if (options.encoding) {
       encoding = options.encoding;
     }
+    if (options.namespace) {
+      namespace = options.namespace;
+    }
   }
 
   try {
     var parsedDoc = parse(fs.readFileSync(path, { encoding: encoding }));
-    
-    Object.keys(parsedDoc).forEach(function(key) {
-      process.env[key] = process.env[key] || parsedDoc[key];
+    var configObject = namespace ? parsedDoc[namespace] : parsedDoc;
+    Object.keys(configObject).forEach(function(key) {
+      process.env[key] = process.env[key] || configObject[key];
     });
 
-    return { parsed: parsedDoc };
+    return { parsed: configObject };
   } catch (e) {
     return { error: e };
   }


### PR DESCRIPTION
Added optional namespace parameter to enable reading configuration values only in a certain namespace. This support scenarios where environment-specific configurations are stored in a single YML file, as when using https://github.com/laserlemon/figaro for instance.